### PR TITLE
Fix composer.json data type for require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
             "email": "eric@cloudcompli.com"
         }
     ],
-    "require": [],
+    "require": {
+        "php": ">=5.5"
+    },
     "require-dev": {
         "php": ">=5.5",
         "phpunit\/phpunit": "4.0.*"


### PR DESCRIPTION
Right now, the JSON encoding for an empty require block is turning an object into an array and causing that to crash. To fix, and because it makes sense to do so, let's move PHP requirement into the `require` block rather than `require-dev`.
